### PR TITLE
ci: set workflow permissions to read-only by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
         default: main
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     permissions:
@@ -20,7 +23,8 @@ jobs:
         ref: ${{ inputs.ref }}
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        check-latest: true
+        node-version: lts/*
     - name: Install dependencies
       run: |
         npm i

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,14 @@ on:
       - main
       - 'releases/*'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -18,6 +23,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -27,12 +34,15 @@ jobs:
 
   integrity:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: checkout repo
       uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        check-latest: true
+        node-version: lts/*
     - name: Build action
       run: |
         npm i &&

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -3,9 +3,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   pull-request-title-check:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
     - uses: fastify/action-pr-title@v0
       with:


### PR DESCRIPTION
This PR adds permissions to the workflow and job level, making the workflows read-only by default, and allowing write access only at the job level via granular permissions. This is regularly flagged by CodeQL, Step Security, [OSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions), and other security tools.
This change also allows the org to go read-only everywhere, see https://github.com/fastify/avvio/pull/308#issuecomment-2765300174