### PR TITLE
ci: remove git credentials after checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v5
       with:
         ref: ${{ inputs.ref }}
+        persist-credentials: false
     - uses: actions/setup-node@v5
       with:
         check-latest: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - run: |
           npm i --ignore-scripts
       - run: |
@@ -27,6 +29,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - run: |
           npm i --ignore-scripts
       - run: |
@@ -39,6 +43,8 @@ jobs:
     steps:
     - name: checkout repo
       uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - uses: actions/setup-node@v5
       with:
         check-latest: true


### PR DESCRIPTION
This PR removes Git credentials after checkout as a security precaution by setting `persist-credentials` to false. They are not used after the initial checkout, and this stops them from accidentally leaking through a script; [see related GitHub security post](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) and [related actions/checkout issue](https://github.com/actions/checkout/issues/485).


Last Fastify repo that needs to happen to, phew!